### PR TITLE
build(release): Go modules for ContinuumLLC fork

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -14,4 +14,4 @@ enabled = true
 
 
   [analyzers.meta]
-  import_path = 'github.com/samuel/go-zookeeper/zk'
+  import_path = 'github.com/ContinuumLLC/go-zookeeper/zk'

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ go:
   - "1.x"
   - tip
 
-go_import_path: github.com/samuel/go-zookeeper
+go_import_path: github.com/ContinuumLLC/go-zookeeper
 
 jdk:
   - oraclejdk9

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -1,0 +1,12 @@
+module github.com/ContinuumLLC/go-zookeeper/examples
+
+go 1.15
+
+// TODO: Change import path in basic.go to use ContinummLLC fork
+// and remove these comments and lines below. This is to avoid
+// the chicken or the egg problem with this changes. Also, run
+// go mod tidy generate the proper go.sum
+
+replace github.com/samuel/go-zookeeper => github.com/ContinuumLLC/go-zookeeper v1.0.0
+
+require github.com/samuel/go-zookeeper v0.0.0-00010101000000-000000000000

--- a/examples/go.sum
+++ b/examples/go.sum
@@ -1,0 +1,2 @@
+github.com/ContinuumLLC/go-zookeeper v1.0.0 h1:NOus737k8ulWcKoLLeuw/p8j2qAfR0UfDKKZlwx4X+s=
+github.com/ContinuumLLC/go-zookeeper v1.0.0/go.mod h1:elzzxiJ6IzDQUHhYJpBaki3B32GsA/RR2s3Klkd3n10=

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,3 @@
-module github.com/samuel/go-zookeeper
+module github.com/ContinuumLLC/go-zookeeper
 
 go 1.15
-
-replace github.com/samuel/go-zookeeper => github.com/ContinuumLLC/go-zookeeper v1.0.0


### PR DESCRIPTION
1. Change go.mod to use ContinuumLLC fork
2. Use Go 1.15 in the go.mod
3. Ran all tests and passed them with the Java ZK
4. TODO Will have to revisit examples dir in order to not break
   the compilation on this check-in. Please refer to the
   examples/go.mod comments for more insights.